### PR TITLE
example: use custom HTML formatter

### DIFF
--- a/example/server/src/style.css
+++ b/example/server/src/style.css
@@ -1,0 +1,16 @@
+body {
+  font-family: monospace;
+}
+
+code {
+  font-family: monospace;
+  background-color: #f4f4f4;
+  padding: 5px;
+  border-radius: 5px;
+}
+
+li {
+  margin-bottom: 15px;
+  line-height: 1.5;
+  list-style-type: none;
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 Divy Srivastava <dj.srivastava23@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use pdb_addr2line::FunctionFrames;
 
 pub trait Formatter {

--- a/src/vlq.rs
+++ b/src/vlq.rs
@@ -11,29 +11,47 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::io::{self, Error, ErrorKind};
 
-pub(crate) fn vlq_decode(
-  input: &mut impl Iterator<Item = u8>,
-) -> std::result::Result<u64, std::io::Error> {
-  let mut result = 0;
-  let mut shift = 0;
-  loop {
-    let byte = input.next().ok_or(std::io::ErrorKind::UnexpectedEof)?;
-    let value = match byte {
-      b'A'..=b'Z' => byte - b'A',
-      b'a'..=b'z' => byte - b'a' + 26,
-      b'0'..=b'9' => byte - b'0' + 52,
-      b'-' => 62,
-      b'_' => 63,
-      _ => return Err(std::io::ErrorKind::InvalidData.into()),
-    };
-    result |= (value as u64 & 31) << shift;
-    if value & 32 == 0 {
-      break;
+fn base64_lut(byte: u8) -> u8 {
+    match byte {
+        b'A'..=b'Z' => byte - b'A',
+        b'a'..=b'z' => byte - b'a' + 26,
+        b'0'..=b'9' => byte - b'0' + 52,
+        b'-' => 62,
+        b'_' => 63,
+        _ => 0,
     }
-    shift += 5;
-  }
-  Ok(result)
+}
+
+pub fn vlq_decode<I>(iter: &mut I) -> Result<i32, Error>
+where
+    I: Iterator<Item = u8>,
+{
+    fn read_byte<I>(iter: &mut I) -> Result<u8, Error>
+    where
+        I: Iterator<Item = u8>,
+    {
+        iter.next().ok_or_else(|| Error::new(ErrorKind::UnexpectedEof, "unexpected EOF"))
+    }
+
+    let mut result = 0;
+    let mut shift = 0;
+    loop {
+        let byte = read_byte(iter)?;
+        let value = base64_lut(byte);
+        result |= ((value & 0b11111) as i32) << shift;
+        shift += 5;
+        if value & 0b100000 == 0 {
+            break;
+        }
+    }
+
+    Ok(if result & 1 == 1 {
+        -(result >> 1)
+    } else {
+        result >> 1
+    })
 }
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]

--- a/src/vlq.rs
+++ b/src/vlq.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::io::{self, Error, ErrorKind};
+use std::io::{Error, ErrorKind};
 
 fn base64_lut(byte: u8) -> u8 {
   match byte {

--- a/src/win64.rs
+++ b/src/win64.rs
@@ -124,6 +124,7 @@ pub fn trace() -> String {
       }
 
       let addr = ip - base;
+      println!("addr: {:#x}", addr);
       vlq_encode(addr as i32, &mut encoded);
 
       let mut hnd_data = 0usize;

--- a/src/win64.rs
+++ b/src/win64.rs
@@ -133,8 +133,6 @@ pub fn trace() -> String {
       );
 
       let addr = addr - handle as usize;
-      println!("addr: {:#x}", addr);
-      dbg!(base, handle as usize);
       vlq_encode(addr as i32, &mut encoded);
 
       let mut hnd_data = 0usize;

--- a/src/win64.rs
+++ b/src/win64.rs
@@ -123,8 +123,18 @@ pub fn trace() -> String {
         break;
       }
 
-      let addr = ip - base;
+      let addr = ip as usize;
+      let mut handle = std::ptr::null_mut();
+      const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 0x4;
+      GetModuleHandleExW(
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        addr as _,
+        &mut handle,
+      );
+
+      let addr = addr - handle as usize;
       println!("addr: {:#x}", addr);
+      dbg!(base, handle as usize);
       vlq_encode(addr as i32, &mut encoded);
 
       let mut hnd_data = 0usize;

--- a/src/win64.rs
+++ b/src/win64.rs
@@ -123,16 +123,7 @@ pub fn trace() -> String {
         break;
       }
 
-      let addr = ip as usize;
-      let mut handle = std::ptr::null_mut();
-      const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 0x4;
-      GetModuleHandleExW(
-        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-        addr as _,
-        &mut handle,
-      );
-
-      let addr = addr - handle as usize;
+      let addr = ip - base;
       vlq_encode(addr as i32, &mut encoded);
 
       let mut hnd_data = 0usize;


### PR DESCRIPTION
`upvCsknB2z8xrB-w7xrB-0qxrBs15xrBonm5zBqsuB2sjC8gMiqiCylyvrB0niCy1uBwltmzBut0L4y_uB`

![image](https://github.com/user-attachments/assets/c35eb733-6065-4dec-ba32-125850a567f7)
